### PR TITLE
Fixing the question-answer page

### DIFF
--- a/components/QuestionAnswerCard.vue
+++ b/components/QuestionAnswerCard.vue
@@ -13,7 +13,7 @@ defineProps({
 
 <template>
   <div class="custom-grid grid">
-    <div>
+    <div class="grid items-center">
       <UiHeadingFour class="m-6 text-center">{{ numAnswers }}</UiHeadingFour>
     </div>
     <div class="my-2 h-auto justify-center bg-black"></div>


### PR DESCRIPTION
Fixing the number centering issue on the question-answer page, now the numbers show up in the middle of the box when the answer is more than 1 line long.